### PR TITLE
fix: share db instance for audit log

### DIFF
--- a/index.html
+++ b/index.html
@@ -1361,5 +1361,15 @@ async function confirmDeleteUniversal(module, id, name = '', extraQty = '') {
   <script src="modules/users_admin.js"></script>
   <script src="modules/audit_log.js"></script>
 
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const b = document.getElementById('bootChecks');
+      if (b) b.textContent = 'وحدات محمّلة: سجل/مستخدمون';
+      if (document.querySelector('.tab.active')?.dataset.tab === 'audit' && typeof renderAudit === 'function') {
+        renderAudit();
+      }
+    });
+  </script>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1318,6 +1318,7 @@ async function confirmDeleteUniversal(module, id, name = '', extraQty = '') {
     CURRENT_USER = username;
     DB_KEY = DB_KEY_BASE; try { const legacy = localStorage.getItem(DB_KEY_BASE + ':' + username); if(legacy && !localStorage.getItem(DB_KEY)) localStorage.setItem(DB_KEY, legacy); } catch(e){}
     db = loadDB();
+    window.db = db;
     whoami.textContent = 'المستخدم: ' + username;
     btnLogout.hidden = false;
     hideAuth();

--- a/modules/audit_log.js
+++ b/modules/audit_log.js
@@ -15,9 +15,7 @@
   // تسجيل حركة + حفظ + رندر فوري
   window.recordAudit = function (action, module, refId, details, qty) {
     try {
-      if (!window.db || typeof window.db !== 'object') {
-        window.db = (typeof loadDB === 'function') ? loadDB() : {};
-      }
+      if (!window.db || typeof window.db !== 'object') return;
       if (!Array.isArray(window.db.audit)) window.db.audit = [];
 
       const me = window.CURRENT_USER || 'unknown';
@@ -50,13 +48,8 @@
     const panel = document.querySelector('section.panel[data-tab="audit"]');
     if (!panel) return;
 
-    // حمّل القاعدة عند الحاجة
-    try {
-      if (!window.db || typeof window.db !== 'object') {
-        window.db = (typeof loadDB === 'function') ? loadDB() : {};
-      }
-      if (!Array.isArray(window.db.audit)) window.db.audit = [];
-    } catch (_) {}
+    // تأكّد من وجود القاعدة في الذاكرة
+    if (!window.db || !Array.isArray(window.db.audit)) return;
 
     // لا تُظهر اللوحة إلا إذا تبويب السجل هو النشط
     const activeTab = document.querySelector('.tab.active')?.dataset.tab;
@@ -161,22 +154,5 @@
       return ret;
     };
   })();
-
-  // عند الإقلاع: حمّل القاعدة، حدّث الشارة، وإن كان تبويب السجل نشط اعرضه فورًا
-  window.addEventListener('DOMContentLoaded', () => {
-    try {
-      if (!window.db || typeof window.db !== 'object') {
-        window.db = (typeof loadDB === 'function') ? loadDB() : {};
-      }
-      if (!Array.isArray(window.db.audit)) window.db.audit = [];
-    } catch (_) {}
-
-    const b = document.getElementById('bootChecks');
-    if (b) b.textContent = 'وحدات محمّلة: سجل/مستخدمون';
-
-    const active = document.querySelector('.tab.active')?.dataset.tab;
-    if (active === 'audit') {
-      setTimeout(() => { try { renderAudit(); } catch (_) {} }, 0);
-    }
-  });
+  // تهيئة أولية تتم في index.html
 })();

--- a/package.json
+++ b/package.json
@@ -12,14 +12,16 @@
     "build:mac": "electron-builder --mac dmg",
     "build:linux": "electron-builder --linux AppImage deb",
     "build": "electron-builder -mwl",
-    "scan": "node tools/selfcheck.js"
+    "scan": "node tools/selfcheck.js",
+    "smoke:audit": "node tools/smoke_audit.js"
   },
   "engines": {
     "node": ">=18"
   },
   "devDependencies": {
     "electron": "^29.0.0",
-    "electron-builder": "^24.9.1"
+    "electron-builder": "^24.9.1",
+    "jsdom": "^24.0.0"
   },
   "build": {
     "appId": "com.ministore.desktop",

--- a/tools/smoke_audit.js
+++ b/tools/smoke_audit.js
@@ -1,0 +1,47 @@
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+const vm = require('vm');
+
+const dom = new JSDOM(`<!DOCTYPE html><body>
+  <div class="tab active" data-tab="audit"></div>
+  <section class="panel" data-tab="audit"></section>
+</body>`, { runScripts: 'outside-only' });
+
+const { window } = dom;
+const { document } = window;
+
+window.saveDB = () => {};
+window.db = { audit: [] };
+for (let i = 0; i < 5; i++) {
+  window.db.audit.push({
+    ts: `2024-01-0${i+1} 00:00:00`,
+    user: 'u',
+    module: 'm',
+    action: 'a',
+    refId: '',
+    details: '',
+    qty: ''
+  });
+}
+
+const auditSrc = fs.readFileSync('modules/audit_log.js', 'utf8');
+vm.runInContext(auditSrc, dom.getInternalVMContext());
+
+const before = window.db.audit.length;
+if (before < 5) {
+  console.error('expected at least 5 audit entries');
+  process.exit(1);
+}
+
+window.renderAudit();
+const rows = document.querySelectorAll('#auditTable tbody tr').length;
+if (!rows) {
+  console.error('renderAudit produced no rows');
+  process.exit(1);
+}
+if (window.db.audit.length !== before) {
+  console.error('renderAudit mutated audit log');
+  process.exit(1);
+}
+
+console.log('smoke:audit ok');

--- a/tools/smoke_audit.js
+++ b/tools/smoke_audit.js
@@ -11,6 +11,7 @@ const { window } = dom;
 const { document } = window;
 
 window.saveDB = () => {};
+window.loadDB = () => { throw new Error('loadDB called'); };
 window.db = { audit: [] };
 for (let i = 0; i < 5; i++) {
   window.db.audit.push({


### PR DESCRIPTION
## Summary
- expose loaded DB on `window` so audit log renders immediately
- harden smoke test to catch unwanted `loadDB` calls

## Testing
- `node tools/selfcheck.js`
- `npm run scan`
- `npm run smoke:audit`
